### PR TITLE
Executable do scripts

### DIFF
--- a/dofile.go
+++ b/dofile.go
@@ -70,8 +70,6 @@ TOP:
 	return &DoInfo{Missing: missing}, nil
 }
 
-const shell = "/bin/sh"
-
 // RunDoFile executes the do file script, records the metadata for the resulting output, then
 // saves the resulting output to the target file, if applicable.
 func (target *File) RunDoFile(doInfo *DoInfo) (err error) {
@@ -194,7 +192,7 @@ func (target *File) runCmd(outputs [2]*Output, doInfo *DoInfo) error {
 
 	target.Debug("@sh %s $3\n", strings.Join(args[0:len(args)-1], " "))
 
-	cmd := exec.Command(shell, args...)
+	cmd := exec.Command(args[0], args[1:]...)
 	cmd.Dir = doInfo.Dir
 	cmd.Stdout = outputs[0]
 	cmd.Stderr = os.Stderr
@@ -239,7 +237,7 @@ TOP:
 	}
 
 	if Verbose() {
-		return target.Errorf("%s %s: %s", shell, strings.Join(args, " "), err)
+		return target.Errorf("%s %s: %s", args[0], strings.Join(args, " "), err)
 	}
 
 	return target.Errorf("%s", err)


### PR DESCRIPTION
Let the os handle the shebang.
Dennis Ritchie has enumerated the advantages:

1) It makes shell scripts more like real executable files,
because they can be the subject of 'exec.'

2) If you do a 'ps' while such a command is running, its real
name appears instead of 'sh'.
Likewise, accounting is done on the basis of the real name.

3) Shell scripts can be set-user-ID.

4) It is simpler to have alternate shells available;
e.g. if you like the Berkeley csh there is no question about
which shell is to interpret a file.

5) It will allow other interpreters to fit in more smoothly.

To take advantage of this wonderful opportunity,
put

```
#! /bin/sh
```

at the left margin of the first line of your shell scripts.
Blanks after ! are OK.  Use a complete pathname (no search is done).
At the moment the whole line is restricted to 16 characters but
this limit will be raised.
